### PR TITLE
ci: add do-not-merge job

### DIFF
--- a/.github/do-not-merge.yml
+++ b/.github/do-not-merge.yml
@@ -1,1 +1,0 @@
-alwaysCreateStatusCheck: true

--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -1,0 +1,26 @@
+name: PR label check
+on:
+  pull_request:
+    types:
+      - opened # for "Require status checks to pass"
+      - synchronize # ditto
+      - labeled
+      - unlabeled
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+
+jobs:
+  do-not-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if ${{ contains(github.event.pull_request.labels.*.name, 'do-not-merge') }}; then
+            false
+          else
+            true
+          fi


### PR DESCRIPTION
GitHub Actions を使って、`do-not-merge` ラベルがついていたらプルリクエストをマージできないようにします。
- 期待通りに動かない Do Not Merge bot を置き換えます。